### PR TITLE
Simplified Settings

### DIFF
--- a/pkg/edge/ICoreWebViewSettings.go
+++ b/pkg/edge/ICoreWebViewSettings.go
@@ -1,0 +1,334 @@
+package edge
+
+import (
+	"golang.org/x/sys/windows"
+	"unsafe"
+)
+
+// ICoreWebviewSettings is the merged settings class
+
+type _ICoreWebViewSettingsVtbl struct {
+	_IUnknownVtbl
+	GetIsScriptEnabled                  ComProc
+	PutIsScriptEnabled                  ComProc
+	GetIsWebMessageEnabled              ComProc
+	PutIsWebMessageEnabled              ComProc
+	GetAreDefaultScriptDialogsEnabled   ComProc
+	PutAreDefaultScriptDialogsEnabled   ComProc
+	GetIsStatusBarEnabled               ComProc
+	PutIsStatusBarEnabled               ComProc
+	GetAreDevToolsEnabled               ComProc
+	PutAreDevToolsEnabled               ComProc
+	GetAreDefaultContextMenusEnabled    ComProc
+	PutAreDefaultContextMenusEnabled    ComProc
+	GetAreHostObjectsAllowed            ComProc
+	PutAreHostObjectsAllowed            ComProc
+	GetIsZoomControlEnabled             ComProc
+	PutIsZoomControlEnabled             ComProc
+	GetIsBuiltInErrorPageEnabled        ComProc
+	PutIsBuiltInErrorPageEnabled        ComProc
+	GetUserAgent                        ComProc
+	PutUserAgent                        ComProc
+	GetAreBrowserAcceleratorKeysEnabled ComProc
+	PutAreBrowserAcceleratorKeysEnabled ComProc
+}
+
+type ICoreWebViewSettings struct {
+	vtbl *_ICoreWebViewSettingsVtbl
+}
+
+func (i *ICoreWebViewSettings) AddRef() uintptr {
+	return i.AddRef()
+}
+
+func (i *ICoreWebViewSettings) GetIsScriptEnabled() (bool, error) {
+	var err error
+	var isScriptEnabled bool
+	_, _, err = i.vtbl.GetIsScriptEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&isScriptEnabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return false, err
+	}
+	return isScriptEnabled, nil
+}
+
+func (i *ICoreWebViewSettings) PutIsScriptEnabled(isScriptEnabled bool) error {
+	var err error
+
+	_, _, err = i.vtbl.PutIsScriptEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(boolToInt(isScriptEnabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return err
+	}
+	return nil
+}
+
+func (i *ICoreWebViewSettings) GetIsWebMessageEnabled() (bool, error) {
+	var err error
+	var isWebMessageEnabled bool
+	_, _, err = i.vtbl.GetIsWebMessageEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&isWebMessageEnabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return false, err
+	}
+	return isWebMessageEnabled, nil
+}
+
+func (i *ICoreWebViewSettings) PutIsWebMessageEnabled(isWebMessageEnabled bool) error {
+	var err error
+
+	_, _, err = i.vtbl.PutIsWebMessageEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(boolToInt(isWebMessageEnabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return err
+	}
+	return nil
+}
+
+func (i *ICoreWebViewSettings) GetAreDefaultScriptDialogsEnabled() (bool, error) {
+	var err error
+	var areDefaultScriptDialogsEnabled bool
+	_, _, err = i.vtbl.GetAreDefaultScriptDialogsEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&areDefaultScriptDialogsEnabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return false, err
+	}
+	return areDefaultScriptDialogsEnabled, nil
+}
+
+func (i *ICoreWebViewSettings) PutAreDefaultScriptDialogsEnabled(areDefaultScriptDialogsEnabled bool) error {
+	var err error
+
+	_, _, err = i.vtbl.PutAreDefaultScriptDialogsEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(boolToInt(areDefaultScriptDialogsEnabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return err
+	}
+	return nil
+}
+
+func (i *ICoreWebViewSettings) GetIsStatusBarEnabled() (bool, error) {
+	var err error
+	var isStatusBarEnabled bool
+	_, _, err = i.vtbl.GetIsStatusBarEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&isStatusBarEnabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return false, err
+	}
+	return isStatusBarEnabled, nil
+}
+
+func (i *ICoreWebViewSettings) PutIsStatusBarEnabled(isStatusBarEnabled bool) error {
+	var err error
+
+	_, _, err = i.vtbl.PutIsStatusBarEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(boolToInt(isStatusBarEnabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return err
+	}
+	return nil
+}
+
+func (i *ICoreWebViewSettings) GetAreDevToolsEnabled() (bool, error) {
+	var err error
+	var areDevToolsEnabled bool
+	_, _, err = i.vtbl.GetAreDevToolsEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&areDevToolsEnabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return false, err
+	}
+	return areDevToolsEnabled, nil
+}
+
+func (i *ICoreWebViewSettings) PutAreDevToolsEnabled(areDevToolsEnabled bool) error {
+	var err error
+	_, _, err = i.vtbl.PutAreDevToolsEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(boolToInt(areDevToolsEnabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return err
+	}
+	return nil
+}
+
+func (i *ICoreWebViewSettings) GetAreDefaultContextMenusEnabled() (bool, error) {
+	var err error
+	var enabled bool
+	_, _, err = i.vtbl.GetAreDefaultContextMenusEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&enabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return false, err
+	}
+	return enabled, nil
+}
+
+func (i *ICoreWebViewSettings) PutAreDefaultContextMenusEnabled(enabled bool) error {
+	var err error
+	_, _, err = i.vtbl.PutAreDefaultContextMenusEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(boolToInt(enabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return err
+	}
+	return nil
+}
+
+func (i *ICoreWebViewSettings) GetAreHostObjectsAllowed() (bool, error) {
+	var err error
+	var allowed bool
+	_, _, err = i.vtbl.GetAreHostObjectsAllowed.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&allowed)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return false, err
+	}
+	return allowed, nil
+}
+
+func (i *ICoreWebViewSettings) PutAreHostObjectsAllowed(allowed bool) error {
+	var err error
+
+	_, _, err = i.vtbl.PutAreHostObjectsAllowed.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(boolToInt(allowed)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return err
+	}
+	return nil
+}
+
+func (i *ICoreWebViewSettings) GetIsZoomControlEnabled() (bool, error) {
+	var err error
+	var enabled bool
+	_, _, err = i.vtbl.GetIsZoomControlEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&enabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return false, err
+	}
+	return enabled, nil
+}
+
+func (i *ICoreWebViewSettings) PutIsZoomControlEnabled(enabled bool) error {
+	var err error
+
+	_, _, err = i.vtbl.PutIsZoomControlEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(boolToInt(enabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return err
+	}
+	return nil
+}
+
+func (i *ICoreWebViewSettings) GetIsBuiltInErrorPageEnabled() (bool, error) {
+	var err error
+	var enabled bool
+	_, _, err = i.vtbl.GetIsBuiltInErrorPageEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&enabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return false, err
+	}
+	return enabled, nil
+}
+
+func (i *ICoreWebViewSettings) PutIsBuiltInErrorPageEnabled(enabled bool) error {
+	var err error
+
+	_, _, err = i.vtbl.PutIsBuiltInErrorPageEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(boolToInt(enabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return err
+	}
+	return nil
+}
+
+func (i *ICoreWebViewSettings) GetUserAgent() (string, error) {
+	var err error
+	// Create *uint16 to hold result
+	var _userAgent *uint16
+	_, _, err = i.vtbl.GetUserAgent.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(_userAgent)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return "", err
+	} // Get result and cleanup
+	userAgent := windows.UTF16PtrToString(_userAgent)
+	windows.CoTaskMemFree(unsafe.Pointer(_userAgent))
+	return userAgent, nil
+}
+
+func (i *ICoreWebViewSettings) PutUserAgent(userAgent string) error {
+	var err error
+	// Convert string 'userAgent' to *uint16
+	_userAgent, err := windows.UTF16PtrFromString(userAgent)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = i.vtbl.PutUserAgent.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(_userAgent)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return err
+	}
+	return nil
+}
+
+func (i *ICoreWebViewSettings) GetAreBrowserAcceleratorKeysEnabled() (bool, error) {
+	var err error
+	var enabled bool
+	_, _, err = i.vtbl.GetAreBrowserAcceleratorKeysEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&enabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return false, err
+	}
+	return enabled, nil
+}
+
+func (i *ICoreWebViewSettings) PutAreBrowserAcceleratorKeysEnabled(enabled bool) error {
+	var err error
+
+	_, _, err = i.vtbl.PutAreBrowserAcceleratorKeysEnabled.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(boolToInt(enabled)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return err
+	}
+	return nil
+}

--- a/pkg/edge/chromium.go
+++ b/pkg/edge/chromium.go
@@ -270,7 +270,7 @@ func (e *Chromium) AcceleratorKeyPressed(sender *ICoreWebView2Controller, args *
 	return 0
 }
 
-func (e *Chromium) GetSettings() (*ICoreWebView2Settings, error) {
+func (e *Chromium) GetSettings() (*ICoreWebViewSettings, error) {
 	return e.webview.GetSettings()
 }
 

--- a/pkg/edge/corewebview2.go
+++ b/pkg/edge/corewebview2.go
@@ -186,9 +186,9 @@ type ICoreWebView2 struct {
 	vtbl *iCoreWebView2Vtbl
 }
 
-func (i *ICoreWebView2) GetSettings() (*ICoreWebView2Settings, error) {
+func (i *ICoreWebView2) GetSettings() (*ICoreWebViewSettings, error) {
 	var err error
-	var settings *ICoreWebView2Settings
+	var settings *ICoreWebViewSettings
 	_, _, err = i.vtbl.GetSettings.Call(
 		uintptr(unsafe.Pointer(i)),
 		uintptr(unsafe.Pointer(&settings)),


### PR DESCRIPTION
- Updated the settings to support `ICoreWebView2Settings3` which allows you to disable all the built-in accelerators like "print".
- Simplified the settings so we have one settings struct type to return, which will prevent further API changes