### PR TITLE
WebView2API For Client-Side

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Go](https://github.com/jchv/go-webview2/actions/workflows/go.yml/badge.svg)](https://github.com/jchv/go-webview2/actions/workflows/go.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/jchv/go-webview2)](https://goreportcard.com/report/github.com/jchv/go-webview2) [![Go Reference](https://pkg.go.dev/badge/github.com/jchv/go-webview2.svg)](https://pkg.go.dev/github.com/jchv/go-webview2)
+[![Go](https://github.com/CanPacis/go-webview2/actions/workflows/go.yml/badge.svg)](https://github.com/CanPacis/go-webview2/actions/workflows/go.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/CanPacis/go-webview2)](https://goreportcard.com/report/github.com/CanPacis/go-webview2) [![Go Reference](https://pkg.go.dev/badge/github.com/CanPacis/go-webview2.svg)](https://pkg.go.dev/github.com/CanPacis/go-webview2)
 
 # go-webview2
 This package provides an interface for using the Microsoft Edge WebView2 component with Go. It is based on [webview/webview](https://github.com/webview/webview) and provides a compatible API.

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/jchv/go-webview2"
+	"github.com/CanPacis/go-webview2"
 )
 
 func main() {

--- a/common.go
+++ b/common.go
@@ -68,16 +68,6 @@ type WebView interface {
 	// to receive notifications about the results of the evaluation.
 	Eval(js string)
 
-	// Bind binds a callback function so that it will appear under the given name
-	// as a global JavaScript function. Internally it uses webview_init().
-	// Callback receives a request string and a user-provided argument pointer.
-	// Request string is a JSON array of all the arguments passed to the
-	// JavaScript function.
-	//
-	// f must be a function
-	// f must return either value and error or just error
-	Bind(name string, f interface{}) error
-
 	// PostMessage imitates a window.postMessage call. It uses webview.Eval under the hood.
 	// It takes a message string, this message should be JSON string or it will
 	// throw an error on the client side.

--- a/common.go
+++ b/common.go
@@ -77,4 +77,9 @@ type WebView interface {
 	// f must be a function
 	// f must return either value and error or just error
 	Bind(name string, f interface{}) error
+
+	// PostMessage imitates a window.postMessage call. It uses webview.Eval under the hood.
+	// It takes a message string, this message should be JSON string or it will
+	// throw an error on the client side.
+	PostMessage(message string) error
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jchv/go-webview2
+module github.com/CanPacis/go-webview2
 
 go 1.16
 

--- a/pkg/edge/ICoreWebView2Controller.go
+++ b/pkg/edge/ICoreWebView2Controller.go
@@ -3,7 +3,7 @@ package edge
 import (
 	"unsafe"
 
-	"github.com/jchv/go-webview2/internal/w32"
+	"github.com/CanPacis/go-webview2/internal/w32"
 	"golang.org/x/sys/windows"
 )
 

--- a/pkg/edge/chromium.go
+++ b/pkg/edge/chromium.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	"github.com/jchv/go-webview2/internal/w32"
+	"github.com/CanPacis/go-webview2/internal/w32"
 	"golang.org/x/sys/windows"
 )
 

--- a/pkg/edge/chromium_amd64.go
+++ b/pkg/edge/chromium_amd64.go
@@ -6,7 +6,7 @@ package edge
 import (
 	"unsafe"
 
-	"github.com/jchv/go-webview2/internal/w32"
+	"github.com/CanPacis/go-webview2/internal/w32"
 )
 
 func (e *Chromium) Resize() {

--- a/pkg/edge/chromium_arm64.go
+++ b/pkg/edge/chromium_arm64.go
@@ -6,7 +6,7 @@ package edge
 import (
 	"unsafe"
 
-	"github.com/jchv/go-webview2/internal/w32"
+	"github.com/CanPacis/go-webview2/internal/w32"
 )
 
 func (e *Chromium) Resize() {

--- a/pkg/edge/corewebview2.go
+++ b/pkg/edge/corewebview2.go
@@ -9,9 +9,9 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/jchv/go-webview2/internal/w32"
+	"github.com/CanPacis/go-webview2/internal/w32"
 
-	"github.com/jchv/go-webview2/webviewloader"
+	"github.com/CanPacis/go-webview2/webviewloader"
 	"golang.org/x/sys/windows"
 )
 

--- a/webview.go
+++ b/webview.go
@@ -45,9 +45,6 @@ type browser interface {
 	Focus()
 }
 
-type apiContext struct {
-}
-
 type webview struct {
 	hwnd       uintptr
 	mainthread uintptr

--- a/webview.go
+++ b/webview.go
@@ -153,7 +153,12 @@ func (w *webview) msgcb(msg string) {
 			return
 		}
 
-		w.PostMessage(string(encoded))
+		err = w.PostMessage(string(encoded))
+
+		if err != nil {
+			log.Printf("could not encode message: %v", err)
+			return
+		}
 	} else {
 		if res, err := w.callbinding(d); err != nil {
 			w.Dispatch(func() {


### PR DESCRIPTION
I created a global WebView2API for a better client-side communication. Also implemented a basic `PostMessage` method that basically evaluates a `postMessage` call that can be listened on the front-end.

I think a global API like this one better aligns with the web standards and would be easier to use. Instead of polluting the global namespace with `webview.Bind` people can communicate between processes in a cleaner manner. Creating global functions also tend to cause problems with TypeScript as well beacuse each of them needs to be declared in a seperate file, at least my experience wasn't the best.

Simple usage would be something like this;

```golang
// While creating a new vebview with options, we can provide a WebView2API handler
w := webview2.NewWithOptions(webview2.WebViewOptions{
    Debug:     true,
    AutoFocus: true,
    WebView2API: apiHandler,
    WindowOptions: webview2.WindowOptions{
        Title: "Minimal webview example",
    },
})

// ...

// Then we would define the method as such;
func apiHandler(message string) interface{} {
    // deal with the message and return any message that is serializable
    return "hello, world!"
}
```

On the client-side we can create a `WebView2API` object and send and listen to messages

```javascript
// First we check if the API is provided
if ("WebView2API" in window) {
    let bridge = new WebView2API();
    await bridge.send(""); // returns "hello, world!"
    
    // We can also listen to arbitrary messages with event listeners as well
    bridge.addEventListener("message", (event) => console.log(event)) // Logs a custom message event
}
```