### PR TITLE
icon & center & debug

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -14,6 +14,8 @@ func main() {
 			Title:  "Minimal webview example",
 			Width:  800,
 			Height: 600,
+			IconId: 2, // icon resource id
+			Center: true,
 		},
 	})
 	if w == nil {

--- a/internal/w32/w32.go
+++ b/internal/w32/w32.go
@@ -44,6 +44,27 @@ var (
 )
 
 const (
+	SM_CXSCREEN = 0
+	SM_CYSCREEN = 1
+)
+
+const (
+	CW_USEDEFAULT = 0x80000000
+)
+
+const (
+	LR_DEFAULTCOLOR     = 0x0000
+	LR_MONOCHROME       = 0x0001
+	LR_LOADFROMFILE     = 0x0010
+	LR_LOADTRANSPARENT  = 0x0020
+	LR_DEFAULTSIZE      = 0x0040
+	LR_VGACOLOR         = 0x0080
+	LR_LOADMAP3DCOLORS  = 0x1000
+	LR_CREATEDIBSECTION = 0x2000
+	LR_SHARED           = 0x8000
+)
+
+const (
 	SystemMetricsCxIcon = 11
 	SystemMetricsCyIcon = 12
 )

--- a/pkg/edge/chromium.go
+++ b/pkg/edge/chromium.go
@@ -31,7 +31,6 @@ type Chromium struct {
 	environment *ICoreWebView2Environment
 
 	// Settings
-	Debug    bool
 	DataPath string
 
 	// permissions


### PR DESCRIPTION
1. Load icon from attached resources created by [akavel/rsrc](https://github.com/akavel/rsrc/), and use it in webview2 window. (#6)
2. Add `Center` option, which could display webview2 window at screen center.
3. The `Debug` option now disables context menu and devtools instead of doing nothing. (#2)