### PR TITLE
Fixes for webviewloader.GetInstalledVersion

### DIFF
--- a/webviewloader/module.go
+++ b/webviewloader/module.go
@@ -24,9 +24,10 @@ var (
 )
 
 // CompareBrowserVersions will compare the 2 given versions and return:
-//  -1 = v1 < v2
-//   0 = v1 == v2
-//   1 = v1 > v2
+//
+//	-1 = v1 < v2
+//	 0 = v1 == v2
+//	 1 = v1 > v2
 func CompareBrowserVersions(v1 string, v2 string) (int, error) {
 
 	_v1, err := windows.UTF16PtrFromString(v1)
@@ -67,30 +68,42 @@ func CompareBrowserVersions(v1 string, v2 string) (int, error) {
 // GetInstalledVersion returns the installed version of the webview2 runtime.
 // If there is no version installed, a blank string is returned.
 func GetInstalledVersion() (string, error) {
+	// GetAvailableCoreWebView2BrowserVersionString is documented as:
+	//	public STDAPI GetAvailableCoreWebView2BrowserVersionString(PCWSTR browserExecutableFolder, LPWSTR * versionInfo)
+	// where winnt.h defines STDAPI as:
+	//	EXTERN_C HRESULT STDAPICALLTYPE
+	// the first part (EXTERN_C) can be ignored since it's only relevent to C++,
+	// HRESULT is return type which means it returns an integer that will be 0 (S_OK) on success,
+	// and finally STDAPICALLTYPE tells us the function uses the stdcall calling convention (what Go assumes for syscalls).
+
 	nativeErr := nativeModule.Load()
 	if nativeErr == nil {
 		nativeErr = nativeGetAvailableCoreWebView2BrowserVersionString.Find()
 	}
-	var err error
+	var hr uintptr
 	var result *uint16
 	if nativeErr != nil {
-		err = loadFromMemory(nativeErr)
-		if err != nil {
+		if err := loadFromMemory(nativeErr); err != nil {
 			return "", fmt.Errorf("Unable to load WebView2Loader.dll from disk: %v -- or from memory: %w", nativeErr, memErr)
 		}
-		_, _, err = memGetAvailableCoreWebView2BrowserVersionString.Call(
+		hr64, _, _ := memGetAvailableCoreWebView2BrowserVersionString.Call(
 			uint64(uintptr(unsafe.Pointer(nil))),
 			uint64(uintptr(unsafe.Pointer(&result))))
+		hr = uintptr(hr64) // The return size of the HRESULT will be whatver native size is (i.e uintptr) and not 64-bits on 32-bit systems.  In both cases it should be interpreted as 32-bits (a LONG).
 	} else {
-		_, _, err = nativeCompareBrowserVersions.Call(
+		hr, _, _ = nativeGetAvailableCoreWebView2BrowserVersionString.Call(
 			uintptr(unsafe.Pointer(nil)),
 			uintptr(unsafe.Pointer(&result)))
 	}
-	if err != nil {
-		return "", err
+	defer windows.CoTaskMemFree(unsafe.Pointer(result)) // Safe even if result is nil
+	if hr != uintptr(windows.S_OK) {
+		if hr&0xFFFF == uintptr(windows.ERROR_FILE_NOT_FOUND) {
+			// The lower 16-bits (the error code itself) of the HRESULT is ERROR_FILE_NOT_FOUND which means the system isn't installed.
+			return "", nil // Return a blank string but no error since we successfully detected no install.
+		}
+		return "", fmt.Errorf("GetAvailableCoreWebView2BrowserVersionString returned HRESULT 0x%X", hr)
 	}
-	version := windows.UTF16PtrToString(result)
-	windows.CoTaskMemFree(unsafe.Pointer(result))
+	version := windows.UTF16PtrToString(result) // Safe even if result is nil
 	return version, nil
 }
 


### PR DESCRIPTION
Addresses the following issues in webviewloader.GetInstalledVersion:
* Copy paste left `nativeCompareBrowserVersions` being called instead of `nativeGetAvailableCoreWebView2BrowserVersionString`
* The `GetAvailableCoreWebView2BrowserVersionString` Win32 function returns a HRESULT, but does not set the last error.  It now uses this HRESULT instead of the err returned by the syscall (which uses GetLastError) itnernally

Additionally I tried to document the changes and oddities should additional fixes be needed in the future.

Note: Change in formatting of the comment was automatic (I've noticed newer versions of the Go tooling format godoc code blocks slightly differently.

Closes #51 