### PR TITLE
Fix Windows 32-bit support for GetWindowLong/SetWindowLong functions

### DIFF
--- a/internal/w32/w32.go
+++ b/internal/w32/w32.go
@@ -37,7 +37,9 @@ var (
 	User32SetWindowTextW     = user32.NewProc("SetWindowTextW")
 	User32PostThreadMessageW = user32.NewProc("PostThreadMessageW")
 	User32GetWindowLongPtrW  = user32.NewProc("GetWindowLongPtrW")
+	User32GetWindowLongW     = user32.NewProc("GetWindowLongW")
 	User32SetWindowLongPtrW  = user32.NewProc("SetWindowLongPtrW")
+	User32SetWindowLongW     = user32.NewProc("SetWindowLongW")
 	User32AdjustWindowRect   = user32.NewProc("AdjustWindowRect")
 	User32SetWindowPos       = user32.NewProc("SetWindowPos")
 	User32IsDialogMessage    = user32.NewProc("IsDialogMessage")
@@ -189,4 +191,28 @@ func SHCreateMemStream(data []byte) (uintptr, error) {
 	}
 
 	return ret, nil
+}
+
+func GetWindowLong(hwnd uintptr, index int) uintptr {
+	if unsafe.Sizeof(uintptr(0)) == 8 {
+		// 64-bit
+		ret, _, _ := User32GetWindowLongPtrW.Call(hwnd, uintptr(index))
+		return ret
+	} else {
+		// 32-bit
+		ret, _, _ := User32GetWindowLongW.Call(hwnd, uintptr(index))
+		return ret
+	}
+}
+
+func SetWindowLong(hwnd uintptr, index int, newLong uintptr) uintptr {
+	if unsafe.Sizeof(uintptr(0)) == 8 {
+		// 64-bit
+		ret, _, _ := User32SetWindowLongPtrW.Call(hwnd, uintptr(index), newLong)
+		return ret
+	} else {
+		// 32-bit
+		ret, _, _ := User32SetWindowLongW.Call(hwnd, uintptr(index), newLong)
+		return ret
+	}
 }

--- a/internal/w32/w32.go
+++ b/internal/w32/w32.go
@@ -36,10 +36,10 @@ var (
 	User32PostMessageW       = user32.NewProc("PostMessageW")
 	User32SetWindowTextW     = user32.NewProc("SetWindowTextW")
 	User32PostThreadMessageW = user32.NewProc("PostThreadMessageW")
-	User32GetWindowLongPtrW  = user32.NewProc("GetWindowLongPtrW")
 	User32GetWindowLongW     = user32.NewProc("GetWindowLongW")
-	User32SetWindowLongPtrW  = user32.NewProc("SetWindowLongPtrW")
+	User32GetWindowLongPtrW  = user32.NewProc("GetWindowLongPtrW")
 	User32SetWindowLongW     = user32.NewProc("SetWindowLongW")
+	User32SetWindowLongPtrW  = user32.NewProc("SetWindowLongPtrW")
 	User32AdjustWindowRect   = user32.NewProc("AdjustWindowRect")
 	User32SetWindowPos       = user32.NewProc("SetWindowPos")
 	User32IsDialogMessage    = user32.NewProc("IsDialogMessage")
@@ -191,28 +191,4 @@ func SHCreateMemStream(data []byte) (uintptr, error) {
 	}
 
 	return ret, nil
-}
-
-func GetWindowLong(hwnd uintptr, index int) uintptr {
-	if unsafe.Sizeof(uintptr(0)) == 8 {
-		// 64-bit
-		ret, _, _ := User32GetWindowLongPtrW.Call(hwnd, uintptr(index))
-		return ret
-	} else {
-		// 32-bit
-		ret, _, _ := User32GetWindowLongW.Call(hwnd, uintptr(index))
-		return ret
-	}
-}
-
-func SetWindowLong(hwnd uintptr, index int, newLong uintptr) uintptr {
-	if unsafe.Sizeof(uintptr(0)) == 8 {
-		// 64-bit
-		ret, _, _ := User32SetWindowLongPtrW.Call(hwnd, uintptr(index), newLong)
-		return ret
-	} else {
-		// 32-bit
-		ret, _, _ := User32SetWindowLongW.Call(hwnd, uintptr(index), newLong)
-		return ret
-	}
 }

--- a/internal/w32/w32_386.go
+++ b/internal/w32/w32_386.go
@@ -1,0 +1,14 @@
+//go:build windows && 386
+// +build windows,386
+
+package w32
+
+func GetWindowLong(hwnd uintptr, index int) uintptr {
+	ret, _, _ := User32GetWindowLongW.Call(hwnd, uintptr(index))
+	return ret
+}
+
+func SetWindowLong(hwnd uintptr, index int, newLong uintptr) uintptr {
+	ret, _, _ := User32SetWindowLongW.Call(hwnd, uintptr(index), newLong)
+	return ret
+}

--- a/internal/w32/w32_64bit.go
+++ b/internal/w32/w32_64bit.go
@@ -1,0 +1,15 @@
+//go:build windows && (amd64 || arm64)
+// +build windows
+// +build amd64 arm64
+
+package w32
+
+func GetWindowLong(hwnd uintptr, index int) uintptr {
+	ret, _, _ := User32GetWindowLongPtrW.Call(hwnd, uintptr(index))
+	return ret
+}
+
+func SetWindowLong(hwnd uintptr, index int, newLong uintptr) uintptr {
+	ret, _, _ := User32SetWindowLongPtrW.Call(hwnd, uintptr(index), newLong)
+	return ret
+}

--- a/webview.go
+++ b/webview.go
@@ -404,13 +404,13 @@ func (w *webview) SetTitle(title string) {
 
 func (w *webview) SetSize(width int, height int, hints Hint) {
 	index := w32.GWLStyle
-	style, _, _ := w32.User32GetWindowLongPtrW.Call(w.hwnd, uintptr(index))
+	style := w32.GetWindowLong(w.hwnd, index)
 	if hints == HintFixed {
 		style &^= (w32.WSThickFrame | w32.WSMaximizeBox)
 	} else {
 		style |= (w32.WSThickFrame | w32.WSMaximizeBox)
 	}
-	_, _, _ = w32.User32SetWindowLongPtrW.Call(w.hwnd, uintptr(index), style)
+	w32.SetWindowLong(w.hwnd, index, style)
 
 	if hints == HintMax {
 		w.maxsz.X = int32(width)


### PR DESCRIPTION
**Problem:**
- GetWindowLongPtrW and SetWindowLongPtrW functions don't exist on 32-bit
- This caused runtime errors at launch for 32-bit binaries

**Solution:**
- Implemented conditional compilation using Go build constraints
- Created architecture-specific implementations:
  - `w32_386.go`: 32-bit implementation using GetWindowLongW/SetWindowLongW
  - `w32_64bit.go`: 64-bit implementation using GetWindowLongPtrW/SetWindowLongPtrW (covers amd64 and arm64)