### PR TITLE
Fix initial visual artifacts, option to start hidden

### DIFF
--- a/common.go
+++ b/common.go
@@ -81,4 +81,11 @@ type WebView interface {
 	// f must be a function
 	// f must return either value and error or just error
 	Bind(name string, f interface{}) error
+
+	// Show shows the native window if hidden.
+	// It will also restore a minimized window.
+	Show()
+
+	// Hide hides the native window from the screen and taskbar.
+	Hide()
 }

--- a/internal/w32/w32.go
+++ b/internal/w32/w32.go
@@ -44,6 +44,7 @@ var (
 	User32SetWindowPos       = user32.NewProc("SetWindowPos")
 	User32IsDialogMessage    = user32.NewProc("IsDialogMessage")
 	User32GetAncestor        = user32.NewProc("GetAncestor")
+	User32IsIconic           = user32.NewProc("IsIconic")
 )
 
 const (
@@ -73,7 +74,9 @@ const (
 )
 
 const (
-	SWShow = 5
+	SWHide    = 0
+	SWShow    = 5
+	SWRestore = 9
 )
 
 const (

--- a/webview.go
+++ b/webview.go
@@ -44,6 +44,7 @@ type browser interface {
 	Eval(script string)
 	NotifyParentWindowPositionChanged() error
 	Focus()
+	Show() error
 }
 
 type webview struct {
@@ -59,11 +60,12 @@ type webview struct {
 }
 
 type WindowOptions struct {
-	Title  string
-	Width  uint
-	Height uint
-	IconId uint
-	Center bool
+	Title       string
+	Width       uint
+	Height      uint
+	IconId      uint
+	Center      bool
+	StartHidden bool
 }
 
 type WebViewOptions struct {
@@ -333,7 +335,6 @@ func (w *webview) CreateWithOptions(opts WindowOptions) bool {
 	)
 	setWindowContext(w.hwnd, w)
 
-	_, _, _ = w32.User32ShowWindow.Call(w.hwnd, w32.SWShow)
 	_, _, _ = w32.User32UpdateWindow.Call(w.hwnd)
 	_, _, _ = w32.User32SetFocus.Call(w.hwnd)
 
@@ -341,7 +342,28 @@ func (w *webview) CreateWithOptions(opts WindowOptions) bool {
 		return false
 	}
 	w.browser.Resize()
+	if !opts.StartHidden {
+		_, _, _ = w32.User32ShowWindow.Call(w.hwnd, w32.SWShow)
+		_ = w.browser.Show()
+	}
 	return true
+}
+
+func (w *webview) Hide() {
+	_, _, _ = w32.User32ShowWindow.Call(w.hwnd, w32.SWHide)
+}
+
+func (w *webview) Show() {
+	ret, _, _ := w32.User32IsIconic.Call(w.hwnd)
+	isMinimized := ret != 0
+
+	if isMinimized {
+		_, _, _ = w32.User32ShowWindow.Call(w.hwnd, w32.SWRestore)
+	} else {
+		_, _, _ = w32.User32ShowWindow.Call(w.hwnd, w32.SWShow)
+	}
+
+	_ = w.browser.Show()
 }
 
 func (w *webview) Destroy() {


### PR DESCRIPTION
When creating a webview, initially there is some artifacting where a blank window will render for a few milliseconds before resizing slightly and then showing properly. From what I gather this is a WebView2 issue. Even hiding the native window immediately upon creation programmatically this artifacting/flashing still occurs.

Here I moved the call to show the native window until after everything is initialized, and this avoids the initial visual artifacts. To make it work I had to also explicitly show the browser at this point, which calls PutIsVisible(true) on the chromium controller, or else the webview would remain blank. I added a Show function to the browser interface in order to be able to call chromium's Show function.

Added the option to start with the native window hidden, as this can be useful in some use cases and allows for pre-initializing the webview. I also added Show and Hide helper functions to the WebView interface to make it easy to toggle visibility.